### PR TITLE
 Only run miralib job if miralib files change 

### DIFF
--- a/.github/workflows/miralib.yml
+++ b/.github/workflows/miralib.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [ master ]
     paths:
-      - '/src/tools/miralib/csharp/**'
+      - 'src/tools/miralib/csharp/**'
   pull_request:
     branches: [ master ]
     paths:
-      - '/src/tools/miralib/csharp/**'
+      - 'src/tools/miralib/csharp/**'
 
 jobs:
   build:

--- a/src/tools/miralib/csharp/MiraConnection.cs
+++ b/src/tools/miralib/csharp/MiraConnection.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
-
+// test
 /// <summary>
 /// Namespace <c>MiraLib</c> contains all the necessary classes and functions for managing consoles on the PC side for applications to use.
 /// </summary>

--- a/src/tools/miralib/csharp/MiraConnection.cs
+++ b/src/tools/miralib/csharp/MiraConnection.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
-// test
+
 /// <summary>
 /// Namespace <c>MiraLib</c> contains all the necessary classes and functions for managing consoles on the PC side for applications to use.
 /// </summary>


### PR DESCRIPTION
This will save you some minutes on your jobs, instead of running this one each time there's a new PR.
Should probably do the same with the other job too, I'll submit another PR for that shortly.