### PR TITLE
Only define __GNUC__ when undefined.

### DIFF
--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -36,7 +36,7 @@
 #ifndef	_SYS_CDEFS_H_
 #define	_SYS_CDEFS_H_
 
-#if __clang_major__ >= 10
+#if __clang_major__ >= 10 && !defined(__GNUC__)
 #define __GNUC__ 3
 #endif
 


### PR DESCRIPTION
Previously would cause a redefinition error if you pass `-fgnuc-version=` to >= clang 10.0