### PR TITLE
Align .got and .got.plt when needed.

### DIFF
--- a/link.x
+++ b/link.x
@@ -22,10 +22,14 @@ SECTIONS
 		*(.data.rel.ro)
 	}
 
+	# Align .got to 0x4000 if .data.rel.ro doesn't exist
+	. = (SIZEOF(.data.rel.ro) > 0 ? . : ALIGN(.,0x4000));
 	.got : {
 		*(.got)
 	}
 
+	# Align .got.plt to 0x4000 if .got doesn't exist
+	. = (SIZEOF(.got) > 0 ? . : ALIGN(.,0x4000));
 	.got.plt : {
 		*(.got.plt)
 	}


### PR DESCRIPTION
Align `.got` and `.got.plt` if `.data.rel.ro` doesn't exist.

`create-eboot`/`create-lib` merge `.data.rel.ro`/`.got.plt` into `PT_SCE_RELRO`. Orbis requires `PT_SCE_RELRO` to be page aligned, at least for libs.