### PR TITLE
Some fixes to samples

### DIFF
--- a/samples/font/font/graphics.cpp
+++ b/samples/font/font/graphics.cpp
@@ -201,7 +201,7 @@ void frameWait(int video, int frameID)
 }
 
 // drawPixel draws the given color to the given x-y coordinates in the frame buffer. Returns nothing.
-void drawPixel(int x, int y, Color color)
+__attribute__((always_inline)) void drawPixel(int x, int y, Color color)
 {
     // Get pixel location based on pitch
     int pixel = (y * Width) + x;

--- a/samples/graphics/graphics/graphics.cpp
+++ b/samples/graphics/graphics/graphics.cpp
@@ -198,7 +198,7 @@ void frameWait(int video, int frameID)
 }
 
 // drawPixel draws the given color to the given x-y coordinates in the frame buffer. Returns nothing.
-void drawPixel(int x, int y, Color color)
+__attribute__((always_inline)) void drawPixel(int x, int y, Color color)
 {
     // Get pixel location based on pitch
     int pixel = (y * Width) + x;

--- a/samples/pngdec/pngdec/graphics.cpp
+++ b/samples/pngdec/pngdec/graphics.cpp
@@ -198,7 +198,7 @@ void frameWait(int video, int frameID)
 }
 
 // drawPixel draws the given color to the given x-y coordinates in the frame buffer. Returns nothing.
-void drawPixel(int x, int y, Color color)
+__attribute__((always_inline)) void drawPixel(int x, int y, Color color)
 {
     // Get pixel location based on pitch
     int pixel = (y * Width) + x;

--- a/src/crt/build.sh
+++ b/src/crt/build.sh
@@ -1,2 +1,6 @@
 as crt1.S -o crt1.o
 as crtlib.S -o crtlib.o
+
+mv ./crt1.o ${OO_PS4_TOOLCHAIN}/lib/crt1.o
+mv ./crtlib.o ${OO_PS4_TOOLCHAIN}/lib/crtlib.o
+


### PR DESCRIPTION
drawPixel() should always be inlined to increase performance.
added mv command to crt build script.