### PR TITLE
Fix (?) GOT index shift

### DIFF
--- a/src/tools/create-eboot/OELFGenDynlibData.go
+++ b/src/tools/create-eboot/OELFGenDynlibData.go
@@ -697,11 +697,9 @@ func writeRelocationTable(orbisElf *OrbisElf, segmentData *[]byte) uint64 {
 
 			oldRelaDynTableData = oldRelaDynTableData[0x18:]
 
-			rInfo += 0x100000000 // increment symbol idx to account for SECTION
-
 			_ = binary.Write(relocationTableBuff, binary.LittleEndian, elf.Rela64{
 				Off:    rOffset,
-				Info:   rInfo,
+				Info:   rInfo + (1 << 32), // Add one to the symbol index to account for STT_SECTION
 				Addend: int64(rAddend),
 			})
 		}

--- a/src/tools/create-eboot/OELFGenDynlibData.go
+++ b/src/tools/create-eboot/OELFGenDynlibData.go
@@ -572,7 +572,9 @@ func writeSymbolTable(orbisElf *OrbisElf, segmentData *[]byte) uint64 {
 				Info: symbol.Info,
 			})
 
-			numSymbols++
+			numSymbols++ // should it go outside?
+		} else {
+			_ = binary.Write(symbolTableBuff, binary.LittleEndian, elf.Sym64{})
 		}
 	}
 
@@ -694,6 +696,8 @@ func writeRelocationTable(orbisElf *OrbisElf, segmentData *[]byte) uint64 {
 			rAddend := orbisElf.ElfToConvert.ByteOrder.Uint64(oldRelaDynTableData[0x10:0x18])
 
 			oldRelaDynTableData = oldRelaDynTableData[0x18:]
+
+			rInfo += 0x100000000 // increment symbol idx to account for SECTION
 
 			_ = binary.Write(relocationTableBuff, binary.LittleEndian, elf.Rela64{
 				Off:    rOffset,


### PR DESCRIPTION
`.rela.dyn` entries that refer to symbols contain an index into `.dynsym` as a number. `create-eboot` however adds an additional `SECTION` entry to `.dynsym`, so all the indices get shifted by 1 and relocations begin referencing wrong symbols.

Closes #82 (needs testing)