### PR TITLE
Simple typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ brew install llvm
 
 In the future, we may include pre-built binaries for clang/lld, however for the present, it is required for you to install these separately.
 
-The `OO_PS4_TOOLCHAIN` environment variable also needs to be set. On Windows, this can be done using the environment variables control panel. On linux and macOS, the following command can be added to `~/.bashrc` (Debian/Ubuntu), `~/.bash_profile` (macOS Mojave and lover) or `~/.zshrc` (macOS Catalina):
+The `OO_PS4_TOOLCHAIN` environment variable also needs to be set. On Windows, this can be done using the environment variables control panel. On linux and macOS, the following command can be added to `~/.bashrc` (Debian/Ubuntu), `~/.bash_profile` (macOS Mojave and lower) or `~/.zshrc` (macOS Catalina):
 
 ```
 export OO_PS4_TOOLCHAIN=[directory of installation]

--- a/extra/macos_pkg_files/post_install_script.sh
+++ b/extra/macos_pkg_files/post_install_script.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-# Movaje and lover
+# Movaje and lower
 echo 'export OO_PS4_TOOLCHAIN=/opt/OpenOrbis-PS4-Toolchain' >> /Users/$USER/.bash_profile
 
 # Catalina

--- a/extra/macos_pkg_files/readme.txt
+++ b/extra/macos_pkg_files/readme.txt
@@ -1,4 +1,4 @@
-OpenOrbis PS4 Toolchain will be installed at /opt/OpenOrbis-PS4-Toolchain and the installer will automatically set the OO_PS4_TOOLCHAIN environment variable for you in both bash (Mojave and lover) and zsh (Catalina) shells. If you use another shell you will need to set the environment variable for yourself.
+OpenOrbis PS4 Toolchain will be installed at /opt/OpenOrbis-PS4-Toolchain and the installer will automatically set the OO_PS4_TOOLCHAIN environment variable for you in both bash (Mojave and lower) and zsh (Catalina) shells. If you use another shell you will need to set the environment variable for yourself.
 
 Some samples are included in /OpenOrbis-PS4-Toolchain/samples and you can find some docs too at /OpenOrbis-PS4-Toolchain/docs.
 


### PR DESCRIPTION
This is a simple PR to fix a typo in the macOS installer messages. (replace `lover` -> `lower`)

thanks for building OpenOrbis! 😄 