### PR TITLE
Initial Docker commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+---
+name: Build and Push to Docker Hub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare Metadata
+        id: prep
+        run: |
+          DOCKER_IMAGE=openorbis/toolchain
+          VERSION=${GITHUB_REF#refs/tags/}
+
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]];
+          then
+            MINOR=${VERSION%.*}
+            MAJOR=${MINOR%.*}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+          fi
+
+          echo ::set-output name=repo::$(echo "$GITHUB_REPOSITORY")
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: GITHUB_REPOSITORY=${{ steps.prep.outputs.repo }},OO_TOOLCHAIN_VERSION=${{ steps.prep.outputs.version }}
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -30,21 +30,21 @@ This one-liner will run the `make` command from your current working directory a
 
 ### Github Actions
 
-The following action will use the Open Orbis Toolchain v0.5 to run `make` in the projects `hello_world` directory.
+The following action will use the Open Orbis Toolchain v0.5 to run `make` in the projects `hello_world` directory, then use `pkg/pkg.gp4` to build a PKG file.
 
 ```yml
 - name: Run Open Orbis Toolchain
-        uses: openorbis/toolchain-action@v1
+        uses: OpenOrbis/toolchain-action@main
         with:
           version: v0.5
-          command: cd hello_world; make
+          command: cd hello_world; make; PkgTool.Core pkg/pkg.gp4 .
 ```
 
-You could also run the [Build Script] `action.sh` from the projects root directory with the latest Open Orbis Toolchain release with the following action:
+You could also run the build script `action.sh` from the projects root directory with the latest Open Orbis Toolchain release with the following action:
 
 ```yml
 - name: Run Open Orbis Toolchain
-        uses: openorbis/toolchain-action@v1
+        uses: OpenOrbis/toolchain-action@main
         with:
           version: latest
           command: bash action.sh
@@ -77,8 +77,8 @@ To use the "[CLI Access]" and "[Single Line Build]" method you must have [Docker
 Some notes to keep in mind:
 
 - This is a minimal Ubuntu 20.04  installation. You'll need to install other applications as necessary
-- The working directory will be the directory the script is located in
-- Use should use relative paths for locations for files within the mounted folder
+- The working directory will be the repo's root directory
+- Use relative paths for locations within the repo's directory
 - **ANY error should stop the Github Action immediately**
 
 ## Other Tips

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,112 @@
+# Open Orbis Toolchain Dockerfile
+
+## Synopsis
+
+The Open Orbis team has put together a Dockerfile to make compiling PKGs with the Open Orbis PS4 Toolchain trivial to do. This makes updating the toolchain simple, stops the environment from becoming contaminated (or contaminating another environment), minimizes the troubleshooting needed for issues, enables building with a particular version, etc. This document is aimed at providing an overview of how to use the Dockerfile to make a developer's life easier. There are multiple methods that can be utilized depending on the developer's individual need at any given time.
+
+## Methods
+
+The most common use case for each method is as follows:
+
+- [Single Line Build]: You are building a PKG file on your local machine.
+- [Github Actions]: Used to check pull requests, generate releases, etc on Github without needing user interaction.
+- [CLI Access]: Testing, debugging, etc.
+
+### Single Line Build
+
+Windows:
+
+```shell
+docker run -w /build -v "%cd%":/build openorbis/toolchain:latest make
+```
+
+Linux/OSX/BSD:
+
+```shell
+docker run -w /build -v "$(pwd)":/build openorbis/toolchain:latest make
+```
+
+This one-liner will run the `make` command from your current working directory as if it were on a machine with the latest Open Orbis Toolchain installed and working as expected. You can use this to launch a custom script as necessary. See the [Build Script] section for some caveats.
+
+### Github Actions
+
+The following action will use the Open Orbis Toolchain v0.5 to run `make` in the projects `hello_world` directory.
+
+```yml
+- name: Run Open Orbis Toolchain
+        uses: openorbis/toolchain-action@v1
+        with:
+          version: v0.5
+          command: cd hello_world; make
+```
+
+You could also run the [Build Script] `action.sh` from the projects root directory with the latest Open Orbis Toolchain release with the following action:
+
+```yml
+- name: Run Open Orbis Toolchain
+        uses: openorbis/toolchain-action@v1
+        with:
+          version: latest
+          command: bash action.sh
+```
+
+### CLI Access
+
+You can open an interactive shell within the container with the following command:
+
+Windows:
+
+```shell
+docker run -it --entrypoint=/bin/sh -v "%cd%":/build openorbis/toolchain
+```
+
+Linux/OSX/BSD:
+
+```shell
+docker run -it --entrypoint=/bin/sh -v "$(pwd)":/build openorbis/toolchain
+```
+
+**Note:** In the above commands only changes made in the `/build` directory will remain as it is the mounted directory and is actually on the host machine.
+
+## Docker
+
+To use the "[CLI Access]" and "[Single Line Build]" method you must have [Docker] installed locally.
+
+## Build Script
+
+Some notes to keep in mind:
+
+- This is a minimal Ubuntu 20.04  installation. You'll need to install other applications as necessary
+- The working directory will be the directory the script is located in
+- Use should use relative paths for locations for files within the mounted folder
+- **ANY error should stop the Github Action immediately**
+
+## Other Tips
+
+- It is possible to specify why Toolchain version to use by specifying the version in the commands. ex. `openorbis/toolchain:v0.5`, you can also use `latest` to use the most recent build.
+- `docker pull openorbis/toolchain` will update your Docker container to the latest release or `docker pull openorbis/toolchain:v0.5` to pull a specific version's update.
+- Always pull the new container's data before deleting old containers as there may be overlap/cached data and will save you download time
+
+## Docker Development
+
+The development of the Dockerfile and this document file can be found [here](https://github.com/OpenOrbis/OpenOrbis-PS4-Toolchain/). This repo uses Github Actions to build and publish the Docker container to Docker Hub automatically on releases. The workflow file can be found [here](https://github.com/OpenOrbis/OpenOrbis-PS4-Toolchain/tree/master/.github/workflows/docker.yml). The Github Action for the toolchain can be found [here](https://github.com/OpenOrbis/toolchain-action).
+
+## Additional Support
+
+Additional support will be provided in the [Open Orbis Discord] server.
+
+[//]: # (These are reference links used in the body of this note and get stripped out when the markdown processor does its job. There is no need to format nicely because it shouldn't be seen. Thanks SO - http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax)
+
+   [Synopsis]: <#synopsis>
+   [Methods]: <#methods>
+   [Single Line Build]: <#single-line-build>
+   [Github Actions]: <#github-actions>
+   [CLI Access]: <#cli-access>
+   [Docker]: <#docker>
+   [Build Script]: <#build-script>
+   [Other Tips]: <#other-tips>
+   [Docker Development]: <#docker-development>
+   [Additional Support]: <#additional-support>
+
+   [Docker]: <https://www.docker.com/>
+   [Open Orbis Discord]: <https://discord.com/invite/GQr8ydn>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# BASE STAGE: Minimal install for what is required for the SDK to run
+FROM ubuntu:20.04 AS base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install needed applications for running the SDK
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential=12.8ubuntu1 \
+      clang=1:10.0-50~exp1 \
+      libicu66=66.1-2ubuntu2 \
+      lld=1:10.0-50~exp1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# SETUP STAGE: Minimal install for what is required to download/setup the SDK
+FROM ubuntu:20.04 as setup
+
+# Install needed applications for downloading/setting up the SDK
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates=20190110ubuntu1.1 \
+      curl=7.68.0-1ubuntu2.2 \
+      tar=1.30+dfsg-7 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set the OO_PS4_TOOLCHAIN environmental variable for later use vs using copy/paste
+ENV OO_PS4_TOOLCHAIN=/lib/OpenOrbisSDK
+
+# Set repo and version from CLI input
+ARG GITHUB_REPOSITORY
+ARG OO_TOOLCHAIN_VERSION
+
+# Download the latest Linux release and extract to the $OO_PS4_TOOLCHAIN directory
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN mkdir -p $OO_PS4_TOOLCHAIN/ && \
+    curl -sL https://github.com/$GITHUB_REPOSITORY/releases/download/$OO_TOOLCHAIN_VERSION/$OO_TOOLCHAIN_VERSION.tar.gz | \
+    tar -xz -C $OO_PS4_TOOLCHAIN/ bin/data bin/linux include lib scripts LICENSE link.x
+
+# RUNTIME STAGE: The final stage where the magic happens
+FROM base as runtime
+
+# Set the environmental variables for the SDK location
+ENV OO_PS4_TOOLCHAIN=/lib/OpenOrbisSDK
+ENV PATH=$OO_PS4_TOOLCHAIN:$OO_PS4_TOOLCHAIN/bin/linux:$PATH
+
+# Set version from CLI input
+ARG OO_TOOLCHAIN_VERSION
+ENV OO_TOOLCHAIN_VERSION=$OO_TOOLCHAIN_VERSION
+
+# Copy the SDK from the setup stage to this stage
+COPY --from=setup ${OO_PS4_TOOLCHAIN} ${OO_PS4_TOOLCHAIN}


### PR DESCRIPTION
- To build you must include build-args for GITHUB_REPOSITORY and OO_TOOLCHAIN_VERSION

    ex. `--build-arg GITHUB_REPOSITORY=OpenOrbis/OpenOrbis-PS4-Toolchain --build-arg OO_TOOLCHAIN_VERSION=v0.5`

- Workflow automatically handles --build-args
- Workflow will fail because of missing secrets
- Workflow triggers on publishing a release
- Current image size with the v0.5 Toolchain is less than 175 MB when compressed