### PR TITLE
add fork example that does not hang

### DIFF
--- a/samples/fork_process/.gitignore
+++ b/samples/fork_process/.gitignore
@@ -1,0 +1,9 @@
+*~
+*.o
+*.bin
+*.pkg
+*.gp4
+*.elf
+*.oelf
+sce_sys
+sce_module

--- a/samples/fork_process/Makefile
+++ b/samples/fork_process/Makefile
@@ -1,0 +1,90 @@
+TITLE      := Forking
+VERSION    := 1.00
+TITLE_ID   := BREW00005
+CONTENT_ID := IV0000-$(TITLE_ID)_00-FORKING000000000
+LIBS       := -lkernel -lc -lSceLibcInternal -lSceSysUtil
+PKG_FILES  := sce_sys/icon0.png sce_sys/param.sfo \
+              sce_module/libc.prx sce_module/libSceFios2.prx \
+              eboot.bin
+
+
+ifndef OO_PS4_TOOLCHAIN
+    $(error OO_PS4_TOOLCHAIN is undefined)
+endif
+
+CC := clang
+LD := ld.lld
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    PATH := $(PATH):$(OO_PS4_TOOLCHAIN)/bin/linux
+endif
+ifeq ($(UNAME_S),Darwin)
+    PATH := $(PATH):$(OO_PS4_TOOLCHAIN)/bin/macos
+endif
+
+
+CFLAGS   := -target x86_64-scei-ps4-elf -funwind-tables -fuse-init-array \
+            -isysroot $(OO_PS4_TOOLCHAIN) -isystem $(OO_PS4_TOOLCHAIN)/include
+
+LDFLAGS  := -m elf_x86_64 -pie --script $(OO_PS4_TOOLCHAIN)/link.x \
+            --eh-frame-hdr -L$(OO_PS4_TOOLCHAIN)/lib $(OO_PS4_TOOLCHAIN)/lib/crt1.o
+
+
+all: $(CONTENT_ID).pkg
+
+
+$(CONTENT_ID).pkg: $(CONTENT_ID).gp4
+	PkgTool.Core pkg_build $< .
+
+
+$(CONTENT_ID).gp4: $(PKG_FILES)
+	create-gp4 -content-id=$(CONTENT_ID) -files='$^' -out=$@
+
+
+sce_sys/param.sfo: Makefile
+	PkgTool.Core sfo_new $@
+	PkgTool.Core sfo_setentry $@ APP_TYPE --type Integer --maxsize 4 --value 1
+	PkgTool.Core sfo_setentry $@ APP_VER --type Utf8 --maxsize 8 --value '$(VERSION)'
+	PkgTool.Core sfo_setentry $@ ATTRIBUTE --type Integer --maxsize 4 --value 0
+	PkgTool.Core sfo_setentry $@ CATEGORY --type Utf8 --maxsize 4 --value 'gd'
+	PkgTool.Core sfo_setentry $@ CONTENT_ID --type Utf8 --maxsize 48 --value '$(CONTENT_ID)'
+	PkgTool.Core sfo_setentry $@ DOWNLOAD_DATA_SIZE --type Integer --maxsize 4 --value 0
+	PkgTool.Core sfo_setentry $@ SYSTEM_VER --type Integer --maxsize 4 --value 0
+	PkgTool.Core sfo_setentry $@ TITLE --type Utf8 --maxsize 128 --value '$(TITLE)'
+	PkgTool.Core sfo_setentry $@ TITLE_ID --type Utf8 --maxsize 12 --value '$(TITLE_ID)'
+	PkgTool.Core sfo_setentry $@ VERSION --type Utf8 --maxsize 8 --value '$(VERSION)'
+
+
+sce_sys/icon0.png: sce_sys Makefile
+	convert -size 512x512 -gravity center label:'$(TITLE)' $@
+
+
+sce_sys:
+	mkdir $@
+
+
+sce_module:
+	mkdir sce_module
+
+
+sce_module/%.prx: sce_module
+	cp $(OO_PS4_TOOLCHAIN)/bin/data/modules/$(@F) $@
+
+
+eboot.bin: eboot.elf
+	create-eboot -in=$< -out=eboot.oelf
+
+
+eboot.elf: main.o mira.o
+	$(LD) $(LDFLAGS) $(LIBS) -o $@ $^
+
+
+%.c.o: %.c
+	$(CC) -c $(CFLAGS) -o $@ $<
+
+
+clean:
+	rm -f eboot.elf eboot.oelf $(PKG_FILES) $(CONTENT_ID).gp4 \
+              $(CONTENT_ID).pkg main.o mira.o
+	rmdir sce_sys sce_module

--- a/samples/fork_process/main.c
+++ b/samples/fork_process/main.c
@@ -1,0 +1,71 @@
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "mira.h"
+
+
+void sceSysUtilSendSystemNotificationWithText();
+void _Exit();
+
+
+static void
+notify(const char *fmt, ...) {
+  va_list args;
+  char str[1024];
+    
+  va_start(args, fmt);
+  vsnprintf(str, sizeof(str), fmt, args);
+  va_end(args);
+
+  sceSysUtilSendSystemNotificationWithText(222, str);
+}
+
+
+static int
+waitpid_exit(pid_t pid) {
+  int status;
+  
+  do {
+    waitpid(pid, &status, WUNTRACED);
+  } while (!WIFEXITED(status) && !WIFSIGNALED(status));
+
+  return WEXITSTATUS(status);
+}
+
+
+int
+main(int argc, char **argv) {
+  pid_t pid;
+  int status;
+  
+  if(mira_jailbreak()) {
+    notify("jailbreak failed");
+  } else {
+    notify("jailbreak succesful");
+  }
+  sleep(5);
+  
+  pid = fork();
+  if (pid == 0) {
+    notify("pid %d says hello", getpid());
+    sleep(5);
+    _Exit(123);
+    
+  } else if (pid < 0) {
+    notify("fork: %s\n", strerror(errno));
+    
+  } else {
+    notify("pid %d terminated (%d)", pid, waitpid_exit(pid));
+  }
+  
+  while(1) {
+    sleep(1);
+  }
+  
+  return 0;
+}
+

--- a/samples/fork_process/mira.c
+++ b/samples/fork_process/mira.c
@@ -1,0 +1,108 @@
+#include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "mira.h"
+
+
+//provided by libkernel
+int pthread_getthreadid_np();
+
+
+typedef struct mira_thread_credentials {
+  uint32_t state;
+
+  int32_t pid;
+  int32_t tid;
+
+  int32_t euid;
+  int32_t ruid;
+  int32_t suid;
+  
+  int32_t groups;
+  int32_t rgid;
+  int32_t sgid;
+  
+  uint32_t prison;
+  uint64_t authid;
+  uint64_t caps[4];
+  uint64_t attrs[4];
+} mira_thread_credentials_t;
+
+#define CAPS_MAX  0xFFFFFFFFFFFFFFFFULL
+
+#define MIRA_INOUT_GET 0
+#define MIRA_INOUT_SET 1
+
+#define IOCTL_INOUT_CREDENTIALS 0xc0704d01
+
+
+int
+mira_get_credentials(mira_thread_credentials_t *cred) {
+  int fd;
+  int rc;
+  
+  memset(cred, 0, sizeof(mira_thread_credentials_t));
+  cred->state = MIRA_INOUT_GET;
+  cred->pid = getpid();
+  cred->tid = pthread_getthreadid_np();
+  
+  if((fd = open("/dev/mira", 0, O_RDWR)) < 0) {
+    return -1;
+  }
+
+  rc = ioctl(fd, IOCTL_INOUT_CREDENTIALS, cred);
+  close(fd);
+
+  return rc;
+}
+
+
+static int
+mira_set_credentials(const mira_thread_credentials_t *cred) {
+  mira_thread_credentials_t cred_copy;
+  int fd;
+  int rc;
+  
+  memcpy(&cred_copy, cred, sizeof(mira_thread_credentials_t));
+  cred_copy.state = MIRA_INOUT_SET;
+
+  if(!cred_copy.pid) {
+    cred_copy.pid = getpid();
+  }
+
+  if(!cred_copy.tid) {
+    cred_copy.tid = pthread_getthreadid_np();
+  }
+  
+  if((fd = open("/dev/mira", 0, O_RDWR)) < 0) {
+    return -1;
+  }
+
+  rc = ioctl(fd, IOCTL_INOUT_CREDENTIALS, &cred_copy);
+  close(fd);
+
+  return rc;
+}
+
+
+int mira_jailbreak(void) {
+  mira_thread_credentials_t cred;
+
+  if(mira_get_credentials(&cred)) {
+    return -1;
+  }
+
+  cred.caps[0] = CAPS_MAX;
+  cred.caps[1] = CAPS_MAX;
+  cred.caps[2] = CAPS_MAX;
+  cred.caps[3] = CAPS_MAX;
+  
+  if(mira_set_credentials(&cred)) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/samples/fork_process/mira.h
+++ b/samples/fork_process/mira.h
@@ -1,0 +1,6 @@
+#ifndef MIRA_H
+#define MIRA_H
+
+int mira_jailbreak(void);
+
+#endif


### PR DESCRIPTION
Hey!

I was unsure on how and where to send this. I apologize if this is the wrong approach.

I seems the SYS_exit syscall used by musl causes some kind of deadlock in the ps4 kernel when invoked from a forked process.
Invoking the SceLibcInternal function _Exit() (note the capital E) works fine though. Ideally, _Exit would be dumped, reverse engineered and implemented in musl.

In any case, here is an example that uses mira to obtain sufficient credentials to invoke the SYS_fork syscall, and then terminates the child proc using the _Exit function provided by SceLibcInternal, without causing a kernel deadlock.

