### PR TITLE
Add flatz' bgft prototypes

### DIFF
--- a/include/orbis/Bgft.h
+++ b/include/orbis/Bgft.h
@@ -1,20 +1,58 @@
 #ifndef _SCE_BGFT_H_
 #define _SCE_BGFT_H_
 
+#include "_types/bgft.h"
+
 #include <stdint.h>
 
 #ifdef __cplusplus 
 extern "C" {
 #endif
 
-// Empty Comment
+typedef int OrbisBgftTaskId;
+
+int sceBgftServiceIntInit(OrbisBgftInitParams* params);
+int sceBgftServiceIntTerm();
+
+int sceBgftServiceDownloadFindTaskByContentId(const char* contentId, OrbisBgftTaskSubType subType, OrbisBgftTaskId* taskId);
+int sceBgftServiceDownloadFindActivePatchTask(const char* unk, OrbisBgftTaskId* taskId);
+int sceBgftServiceDownloadFindActivePupTask(OrbisBgftTaskId* taskId);
+
+int sceBgftServiceDownloadStartTask(OrbisBgftTaskId taskId);
+int sceBgftServiceDownloadStartTaskAll(void);
+int sceBgftServiceDownloadPauseTask(OrbisBgftTaskId taskId);
+int sceBgftServiceDownloadPauseTaskAll(void);
+int sceBgftServiceDownloadResumeTask(OrbisBgftTaskId taskId);
+int sceBgftServiceDownloadResumeTaskAll(void);
+int sceBgftServiceDownloadStopTask(OrbisBgftTaskId taskId);
+int sceBgftServiceDownloadStopTaskAll(void);
+
+int sceBgftServiceDownloadGetProgress(OrbisBgftTaskId taskId, OrbisBgftTaskProgress* progress);
+
+int sceBgftServiceIntDownloadRegisterTask(OrbisBgftDownloadParam* params, OrbisBgftTaskId* taskId);
+int sceBgftServiceIntDownloadRegisterTaskByStorageEx(OrbisBgftDownloadParamEx* params, OrbisBgftTaskId* taskId);
+int sceBgftServiceIntDownloadRegisterTaskStore(OrbisBgftDownloadParam* params, OrbisBgftTaskId* taskId, OrbisBgftDownloadRegisterErrorInfo* errorInfo);
+int sceBgftServiceIntDownloadUnregisterTask(OrbisBgftTaskId taskId);
+int sceBgftServiceIntDownloadReregisterTaskPatch(OrbisBgftTaskId oldTaskId, OrbisBgftTaskId* newTaskId);
+
+int sceBgftServiceIntDownloadStartTask(OrbisBgftTaskId taskId);
+int sceBgftServiceIntDownloadStopTask(OrbisBgftTaskId taskId);
+int sceBgftServiceIntDownloadPauseTask(OrbisBgftTaskId taskId);
+int sceBgftServiceIntDownloadResumeTask(OrbisBgftTaskId taskId);
+
+int sceBgftServiceIntDownloadGetTaskInfo(OrbisBgftTaskId taskId, OrbisBgftDownloadTaskInfo* taskInfo);
+
+int sceBgftServiceIntDownloadGetProgress(OrbisBgftTaskId taskId, OrbisBgftTaskProgress* progress);
+int sceBgftServiceIntDownloadGetPatchProgress(const char* contentId, OrbisBgftTaskProgress* progress);
+int sceBgftServiceIntDownloadGetPlayGoProgress(const char* contentId, OrbisBgftTaskProgress* progress);
+int sceBgftServiceIntDownloadGetGameAndGameAcProgress(const char* contentId, OrbisBgftTaskProgress* progress);
+
+int sceBgftServiceIntDownloadFindActiveGameAndGameAcTask(const char* contentId, OrbisBgftTaskId* taskId);
+int sceBgftServiceIntDownloadFindActiveTask(const char* contentId, OrbisBgftTaskSubType subType, OrbisBgftTaskId* taskId);
+
+int sceBgftServiceIntDebugDownloadRegisterPkg(OrbisBgftDownloadParam* params, OrbisBgftTaskId* taskId);
+
 void sceBgftServiceDownloadQueryTask();
-// Empty Comment
-void sceBgftServiceDownloadStopTask();
-// Empty Comment
-int sceBgftInitialize(void* parameters);
-// Empty Comment
-int sceBgftFinalize();
 
 #endif
 

--- a/include/orbis/_types/bgft.h
+++ b/include/orbis/_types/bgft.h
@@ -1,0 +1,92 @@
+#pragma once
+
+struct _OrbisBgftInitParams {
+	void* heap;
+	size_t heapSize;
+};
+typedef struct _OrbisBgftInitParams OrbisBgftInitParams;
+
+enum _OrbisBgftTaskSubType {
+	ORBIS_BGFT_TASK_SUB_TYPE_UNKNOWN = 0,
+	ORBIS_BGFT_TASK_SUB_TYPE_PHOTO = 1,
+	ORBIS_BGFT_TASK_SUB_TYPE_MUSIC = 2,
+	ORBIS_BGFT_TASK_SUB_TYPE_VIDEO = 3,
+	ORBIS_BGFT_TASK_SUB_TYPE_MARLIN_VIDEO = 4,
+	ORBIS_BGFT_TASK_SUB_TYPE_UPDATA_ORBIS = 5,
+	ORBIS_BGFT_TASK_SUB_TYPE_GAME = 6,
+	ORBIS_BGFT_TASK_SUB_TYPE_GAME_AC = 7,
+	ORBIS_BGFT_TASK_SUB_TYPE_GAME_PATCH = 8,
+	ORBIS_BGFT_TASK_SUB_TYPE_GAME_LICENSE = 9,
+	ORBIS_BGFT_TASK_SUB_TYPE_SAVE_DATA = 10,
+	ORBIS_BGFT_TASK_SUB_TYPE_CRASH_REPORT = 11,
+	ORBIS_BGFT_TASK_SUB_TYPE_PACKAGE = 12,
+	ORBIS_BGFT_TASK_SUB_TYPE_MAX = 13,
+};
+typedef enum _OrbisBgftTaskSubType OrbisBgftTaskSubType;
+
+enum _OrbisBgftTaskOpt {
+	ORBIS_BGFT_TASK_OPT_NONE = 0x0,
+	ORBIS_BGFT_TASK_OPT_DELETE_AFTER_UPLOAD = 0x1,
+	ORBIS_BGFT_TASK_OPT_INVISIBLE = 0x2,
+	ORBIS_BGFT_TASK_OPT_ENABLE_PLAYGO = 0x4,
+	ORBIS_BGFT_TASK_OPT_FORCE_UPDATE = 0x8,
+	ORBIS_BGFT_TASK_OPT_REMOTE = 0x10,
+	ORBIS_BGFT_TASK_OPT_COPY_CRASH_REPORT_FILES = 0x20,
+	ORBIS_BGFT_TASK_OPT_DISABLE_INSERT_POPUP = 0x40,
+	ORBIS_BGFT_TASK_OPT_INTERNAL = 0x80, /* ignores release date */
+	ORBIS_BGFT_TASK_OPT_DISABLE_CDN_QUERY_PARAM = 0x10000,
+};
+typedef enum _OrbisBgftTaskOpt OrbisBgftTaskOpt;
+
+struct _OrbisBgftDownloadRegisterErrorInfo {
+	/* TODO */
+	uint8_t buf[0x100];
+};
+typedef struct _OrbisBgftDownloadRegisterErrorInfo OrbisBgftDownloadRegisterErrorInfo;
+
+struct _OrbisBgftDownloadParam {
+	int userId;
+	int entitlementType;
+	const char* id; /* max size = 0x30 */
+	const char* contentUrl; /* max size = 0x800 */
+	const char* contentExUrl;
+	const char* contentName; /* max size = 0x259 */
+	const char* iconPath; /* max size = 0x800 */
+	const char* skuId;
+	OrbisBgftTaskOpt option;
+	const char* playgoScenarioId;
+	const char* releaseDate;
+	const char* packageType;
+	const char* packageSubType;
+	unsigned long packageSize;
+};
+typedef struct _OrbisBgftDownloadParam OrbisBgftDownloadParam;
+
+struct _OrbisBgftDownloadParamEx {
+	OrbisBgftDownloadParam params;
+	unsigned int slot;
+};
+typedef struct _OrbisBgftDownloadParamEx OrbisBgftDownloadParamEx;
+
+struct _OrbisBgftDownloadTaskInfo {
+	char* contentTitle;
+	char* iconPath;
+	unsigned long notificationUtcTick;
+};
+typedef struct _OrbisBgftDownloadTaskInfo OrbisBgftDownloadTaskInfo;
+
+struct _OrbisBgftTaskProgress {
+	unsigned int bits;
+	int errorResult;
+	unsigned long length;
+	unsigned long transferred;
+	unsigned long lengthTotal;
+	unsigned long transferredTotal;
+	unsigned int numIndex;
+	unsigned int numTotal;
+	unsigned int restSec;
+	unsigned int restSecTotal;
+	int preparingPercent;
+	int localCopyPercent;
+};
+typedef struct _OrbisBgftTaskProgress OrbisBgftTaskProgress;

--- a/include/orbis/_types/bgft.h
+++ b/include/orbis/_types/bgft.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// https://github.com/flatz/ps4_stub_lib_maker_v2/blob/master/include/bgft.h
+
 struct _OrbisBgftInitParams {
 	void* heap;
 	size_t heapSize;


### PR DESCRIPTION
All credits to flatz for reverse engineering these, I've fixed the names so they're valid. It is been tested.

Sources:
args: https://github.com/flatz/ps4_stub_lib_maker_v2/blob/master/include/bgft.h
nids: https://github.com/flatz/ps4_stub_lib_maker_v2/blob/master/lib/libSceBgft/libSceBgft.def
real names: https://github.com/idc/ps4libdoc/blob/5.05/system/common/lib/libSceBgft.sprx.json