### PR TITLE
Add zlib prototypes.

### DIFF
--- a/include/orbis/Zlib.h
+++ b/include/orbis/Zlib.h
@@ -7,16 +7,16 @@
 extern "C" {
 #endif
 
-// Empty Comment
-void sceZlibFinalize();
-// Empty Comment
-void sceZlibGetResult();
-// Empty Comment
-void sceZlibInflate();
-// Empty Comment
-void sceZlibInitialize();
-// Empty Comment
-void sceZlibWaitForDone();
+// do not call while you're decompressing something.
+int sceZlibFinalize(void);
+// the actual length of decompressed data will be written to destlen. *result should be 0 if ok.
+int sceZlibGetResult(uint64_t id, uint32_t *destlen, int32_t *result);
+// destlen cannot be larger than 0x10000.
+int sceZlibInflate(void *src, uint32_t srclen, void *dest, uint32_t destlen, uint64_t *id);
+// pass NULL and 0 for both arguments respectively.
+int sceZlibInitialize(void *, uint64_t);
+// if maxtimeforwait is NULL it means wait till decompression is done.
+int sceZlibWaitForDone(uint64_t *id, uint32_t *maxtimeforwait);
 
 #endif
 


### PR DESCRIPTION
Sample:
```c
#include <orbis/libkernel.h>
#include <orbis/Zlib.h>
#include <orbis/Sysmodule.h>
#include <stdio.h>
#include <string.h>
#include <stdlib.h>

/* https://pastebin.com/zUHjPup9 */

#define ERRCHECK(errcode) if ((errcode) != (0)) { printf("\n-- Error code is not OK, line=%d, err=%d. --\n", (__LINE__ - 1), (errcode)); for(;;); }

int main(void)
{   
	// No buffering
	setvbuf(stdout, NULL, _IONBF, 0);

	// ORBIS_ error code
	int err = 0;
	
	// memory where to store decompressed data. should be enough.
	const int decomp_len = 0x100000;
	const int decomp_align = 0x4000;
	off_t decomp_off = 0;
	void* mem = NULL; // the final memory address.
	err = sceKernelAllocateDirectMemory(0, sceKernelGetDirectMemorySize(), decomp_len, decomp_align, 0, &decomp_off);
	ERRCHECK(err);
	err = sceKernelMapDirectMemory(&mem, decomp_len, ORBIS_KERNEL_PROT_CPU_RW, 0, decomp_off, decomp_align);
	ERRCHECK(err);

	// first half of the memory block contains compressed data
	// second half will contain the decompressed data
	const uintptr_t dest_mem_offset = decomp_len / 2;
	void* dest_mem = (void*)((uintptr_t)mem + dest_mem_offset);

	// initialize the whole memory block with zeroes.
	memset(mem, 0, decomp_len);

	// copy compressed data into the direct memory region we allocated.
	memcpy(mem, compressed_data, compressed_data_length);

	// scezlib stuff
	uint64_t id = 0; // a weird id that is needed to check the result of inflate.
	int32_t result = 0; // GetResult outcome. (0 is OK)
	uint32_t resultlen = 0; // the actual length of decompressed data.

	// don't forget to load the SceZlib sysmodule.
	err = sceSysmoduleLoadModule(0xc5);
	ERRCHECK(err);
	// initialize the library.
	err = sceZlibInitialize(NULL, 0);
	ERRCHECK(err);
	// the actual decompression starts here.
	err = sceZlibInflate(mem, compressed_data_length, dest_mem, 0x10000, &id);
	ERRCHECK(err);
	// if maxtime is NULL it waits until the very end.
	err = sceZlibWaitForDone(&id, NULL);
	ERRCHECK(err);
	// get the result of decompression.
	err = sceZlibGetResult(id, &resultlen, &result);
	ERRCHECK(err);
	ERRCHECK(result);
	// and tell the library that we are done.
	err = sceZlibFinalize();
	ERRCHECK(err);
	// unload zlib.
	err = sceSysmoduleUnloadModule(0xc5);
	ERRCHECK(err);
	// done.

	// print the results!
	printf("-- zlib decompress result: --\n");
	printf("  -- length: %u (should be bigger than 0)\n", resultlen);
	printf("  -- data:   %s\n", (char *)dest_mem);
	printf("-- done --\n");
	
	// free our memory block.
	err = sceKernelMunmap(mem, decomp_len);
	ERRCHECK(err);
	err = sceKernelReleaseDirectMemory(decomp_off, decomp_len);
	ERRCHECK(err);
	mem = NULL;

	// we're done here.
	printf("-- looping forever... --\n");
	for (;;);
}
```