### PR TITLE
Fix various header issues

### DIFF
--- a/include/orbis/Http.h
+++ b/include/orbis/Http.h
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <stdint.h>
 #include <orbis/_types/http.h>
 

--- a/include/orbis/NetCtl.h
+++ b/include/orbis/NetCtl.h
@@ -1,9 +1,9 @@
 #ifndef _SCE_NET_CTL_H_
 #define _SCE_NET_CTL_H_
 
-#include <sys/stdint.h>
+#include <stdint.h>
 
-#ifdef __cplusplus 
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -55,8 +55,9 @@ typedef union OrbisNetCtlInfo {
 	uint16_t http_proxy_port;
 } OrbisNetCtlInfo;
 
-void sceNetCtlGetInfo(int, void *);
-void sceNetCtlInit();
+int sceNetCtlGetInfo(int, OrbisNetCtlInfo *);
+int sceNetCtlInit();
+void sceNetCtlTerm();
 
 #endif
 

--- a/include/orbis/_types/ime_dialog.h
+++ b/include/orbis/_types/ime_dialog.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 typedef enum {
 	ORBIS_DIALOG_OK = 0,
 	ORBIS_DIALOG_CANCEL = 1,

--- a/include/orbis/_types/kernel.h
+++ b/include/orbis/_types/kernel.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <sys/time.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
 #ifndef MAP_TYPE
 	#define MAP_TYPE 0x0f


### PR DESCRIPTION
Both `u_short` and `u_int` are used in `_types/kernel.h` but are defined in `sys/types.h` if `sys/types.h` is not included elsewhere first it will cause a compilation error