### PR TITLE
Fix missing symbol name when not found

### DIFF
--- a/src/tools/create-eboot/OELFGenDynlibData.go
+++ b/src/tools/create-eboot/OELFGenDynlibData.go
@@ -476,7 +476,7 @@ func writeNIDTable(orbisElf *OrbisElf, segmentData *[]byte) (uint64, error) {
 		}
 
 		if symbolModuleIndex < 0 {
-			return 0, errors.New("missing module for symbol")
+			return 0, errors.New(fmt.Sprintf("missing module for symbol (%s)", symbol.Name))
 		}
 
 		// Build the NID and insert it into the table


### PR DESCRIPTION
Output which symbol was not able to be found.