### PR TITLE
Fix SaveData.h compiling error

### DIFF
--- a/include/orbis/SaveData.h
+++ b/include/orbis/SaveData.h
@@ -73,10 +73,8 @@ void sceSaveDataTransferringMount();
 // Empty Comment
 void sceSaveDataUmountWithBackup();
 
-
-
-#endif
-
 #ifdef __cplusplus
 }
+#endif
+
 #endif


### PR DESCRIPTION
This fixes an issue where including SaveData.h multiple times causes compilation to fail. 