### PR TITLE
Fix #178

### DIFF
--- a/include/orbis/_types/pthread.h
+++ b/include/orbis/_types/pthread.h
@@ -1,6 +1,7 @@
 #pragma once 
 
 #include <stdint.h>
+#include <sys/types.h>
 
 #define ORBIS_PTHREAD_DESTRUCTOR_ITERATIONS	4
 #define ORBIS_PTHREAD_KEYS_MAX			256

--- a/samples/audio-wav/README.md
+++ b/samples/audio-wav/README.md
@@ -14,7 +14,7 @@ This project contains example code for decoding and playing a 16-bit signed PCM 
 samples/audio-wav
 |-- assets
     |-- audio
-        |-- lets_go_go_go_tigerblood_jewel.wav    // wav file to decode and display
+        |-- lets_go_go_go_tigerblood_jewel.wav    // WAV file to decode and display
 |-- audio-wav
     |-- x64
         |-- Debug                                 // Object files / intermediate directory
@@ -22,6 +22,7 @@ samples/audio-wav
     |-- audio-wav.vcxproj.filters
     |-- audio-wav.cvxproj.user
     |-- build.bat                                 // Batch file for building on Windows
+    |-- dr_wav.h                                  // WAV audio loader and writer
     |-- main.cpp                                  // Main source file
 |-- sce_module                                    // Dependency modules for the pkg
     |-- libSceFios2.prx

--- a/samples/audio-wav/README.md
+++ b/samples/audio-wav/README.md
@@ -23,7 +23,6 @@ samples/audio-wav
     |-- audio-wav.cvxproj.user
     |-- build.bat                                 // Batch file for building on Windows
     |-- main.cpp                                  // Main source file
-    |-- wav.cpp                                   // Contains definition for wav data to play
 |-- sce_module                                    // Dependency modules for the pkg
     |-- libSceFios2.prx
     |-- libc.prx

--- a/samples/audio-wav/audio-wav/audio-wav.vcxproj
+++ b/samples/audio-wav/audio-wav/audio-wav.vcxproj
@@ -61,7 +61,6 @@ del /s /q /f $(IntDir)\*.oelf</NMakeCleanCommandLine>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="build.bat" />
-    <ClCompile Include="wav.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="dr_wav.h" />

--- a/samples/audio-wav/audio-wav/audio-wav.vcxproj.filters
+++ b/samples/audio-wav/audio-wav/audio-wav.vcxproj.filters
@@ -19,7 +19,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="build.bat" />
-    <ClCompile Include="wav.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Needs testing on Windows,  but it builds and works on Linux without `wav.cpp`