### PR TITLE
Add extension controller support to Pad.h header.

### DIFF
--- a/include/orbis/Pad.h
+++ b/include/orbis/Pad.h
@@ -21,14 +21,18 @@ extern "C" {
 
 int scePadInit(void);
 int scePadOpen(int userID, int type, int index, void *param);
+int scePadOpenExt(int userID, int type, int index, OrbisPadExtParam *param);
 int scePadClose(int handle);
 int scePadRead(int handle, OrbisPadData *data, int count);
-int scePadReadState(int handle, void *data);
+int scePadReadState(int handle, OrbisPadData *data);
 int scePadResetLightBar(int handle);
 int scePadSetLightBar(int handle, OrbisPadColor *inputColor);
+int scePadGetControllerInformation(int handle, OrbisPadInformation *info);
+int scePadGetExtControllerInformation(int handle, OrbisPadInformation *info);
 int scePadGetHandle(int userID, uint32_t controller_type, uint32_t controller_index);
 int scePadResetOrientation(int handle);
 int scePadSetVibration(int handle, const OrbisPadVibeParam *param);
+int scePadOutputReport(int handle, int type, uint8_t *report, int length);
 
 // The below functions are currently not reversed
 void scePadConnectPort();
@@ -44,11 +48,9 @@ void scePadEnableSpecificDeviceClass();
 void scePadEnableUsbConnection();
 void scePadGetBluetoothAddress();
 void scePadGetCapability();
-void scePadGetControllerInformation();
 void scePadGetDataInternal();
 void scePadGetDeviceId();
 void scePadGetDeviceInfo();
-void scePadGetExtControllerInformation();
 void scePadGetExtensionUnitInfo();
 void scePadGetFeatureReport();
 void scePadGetIdleCount();
@@ -67,9 +69,7 @@ void scePadIsMoveReproductionModel();
 void scePadIsValidHandle();
 void scePadMbusInit();
 void scePadMbusTerm();
-void scePadOpenExt();
 void scePadOpenExt2();
-void scePadOutputReport();
 void scePadReadBlasterForTracker();
 void scePadReadExt();
 void scePadReadForTracker();

--- a/include/orbis/_types/pad.h
+++ b/include/orbis/_types/pad.h
@@ -3,6 +3,14 @@
 #include <stdint.h>
 
 #define ORBIS_PAD_PORT_TYPE_STANDARD 0
+#define ORBIS_PAD_PORT_TYPE_SPECIAL  2
+
+#define ORBIS_PAD_DEVICE_CLASS_PAD    0
+#define ORBIS_PAD_DEVICE_CLASS_GUITAR 1
+#define ORBIS_PAD_DEVICE_CLASS_DRUMS  2
+
+#define ORBIS_PAD_CONNECTION_TYPE_STANDARD 0
+#define ORBIS_PAD_CONNECTION_TYPE_REMOTE   2
 
 #define ORBIS_PAD_BUTTON_L3           0x0002
 #define ORBIS_PAD_BUTTON_R3           0x0004
@@ -98,3 +106,24 @@ typedef struct OrbisPadVibeParam {
 	uint8_t lgMotor;
 	uint8_t smMotor;
 } OrbisPadVibeParam;
+
+// Vendor information about which controller to open for scePadOpenExt
+typedef struct _OrbisPadExtParam {
+    uint16_t vendorId;
+    uint16_t productId;
+    uint16_t productId_2; // this is in here twice?
+    uint8_t unknown[10];
+} OrbisPadExtParam;
+
+typedef struct _OrbisPadInformation {
+	float touchpadDensity;
+	uint16_t touchResolutionX;
+	uint16_t touchResolutionY;
+	uint8_t stickDeadzoneL;
+	uint8_t stickDeadzoneR;
+	uint8_t connectionType;
+	uint8_t count;
+	int connected;
+	int deviceClass;
+	uint8_t unknown[8];
+} OrbisPadInformation;


### PR DESCRIPTION
Adds functions and structures used to connect to extension controllers (guitars, drums etc) as used in GHLive and RB4.

* scePadOpenExt appears to be used for connecting an extension controller with a provided VID/PID (but maybe this isn't required or maybe scePadOpen also accepts that data?)
* scePadReadState returns identical output to scePadRead, just without the "count" parameter.
* scePadOutputReport is used to send a USB control request to the controller. This is required to get outputs from the GHLive dongle.
* scePadGetControllerInformation returns touchpad/stick data, whether remote play is being used, and the class of the device. (the class is used by those two games to determine the instrument)
    * scePadGetExtControllerInformation is seemingly identical.