### PR TITLE
Add some definitions for GnmDriver and VideoOut

### DIFF
--- a/include/orbis/GnmDriver.h
+++ b/include/orbis/GnmDriver.h
@@ -37,8 +37,11 @@ void sceGnmDispatchIndirect();
 void sceGnmDispatchIndirectOnMec();
 // Empty Comment
 void sceGnmDispatchInitDefaultHardwareState();
-// Empty Comment
-void sceGnmDrawIndex();
+// Queue a draw indexed instruction into the command buffer.
+int32_t sceGnmDrawIndex(
+	uint32_t* cmd, uint32_t numdwords, uint32_t indexcount,
+	const void* indexaddr, OrbisGnmDrawIndexFlags flags
+);
 // Empty Comment
 void sceGnmDrawIndexAuto();
 // Empty Comment
@@ -169,10 +172,14 @@ void sceGnmSetGsShader();
 void sceGnmSetHsShader();
 // Empty Comment
 void sceGnmSetLsShader();
-// Empty Comment
-void sceGnmSetPsShader();
-// Empty Comment
-void sceGnmSetPsShader350();
+// Set the pixel shader to be used in the command buffer.
+int32_t sceGnmSetPsShader(
+	uint32_t* cmd, uint32_t numdwords, const void* psregs
+);
+// Set the pixel shader to be used in the command buffer.
+int32_t sceGnmSetPsShader350(
+	uint32_t* cmd, uint32_t numdwords, const void* psregs
+);
 // Empty Comment
 void sceGnmSetResourceRegistrationUserMemory();
 // Empty Comment
@@ -185,20 +192,26 @@ void sceGnmSetSpiEnableSqCountersForUnitInstance();
 void sceGnmSetupMipStatsReport();
 // Empty Comment
 void sceGnmSetVgtControl();
-// Empty Comment
-void sceGnmSetVsShader();
+// Set the vertex shader to be used in the command buffer.
+int32_t sceGnmSetVsShader(
+	uint32_t* cmd, uint32_t numdwords,
+	const void* vsregs, uint32_t shadermodifier
+);
 // Empty Comment
 void sceGnmSetWaveLimitMultipliers();
 // Empty Comment
 void sceGnmSubmitAndFlipCommandBuffers();
 // Empty Comment
 void sceGnmSubmitAndFlipCommandBuffersForWorkload();
-// Empty Comment
-void sceGnmSubmitCommandBuffers();
+// Submit one or more draw command buffer, and optionally one or more compute command buffers.
+int32_t sceGnmSubmitCommandBuffers(
+	uint32_t count, void* dcbaddrs[], uint32_t* dcbbytesizes,
+	void* ccbaddrs[], uint32_t* ccbbytesizes
+);
 // Empty Comment
 void sceGnmSubmitCommandBuffersForWorkload();
 // Empty Comment
-void sceGnmSubmitDone();
+int32_t sceGnmSubmitDone(void);
 // Empty Comment
 void sceGnmUnmapComputeQueue();
 // Empty Comment

--- a/include/orbis/_types/gnm.h
+++ b/include/orbis/_types/gnm.h
@@ -1,3 +1,12 @@
 #pragma once 
 
 #include <stdint.h>
+
+typedef union OrbisGnmDrawIndexFlags {
+	struct {
+		uint32_t predication : 1;
+		uint32_t _unused : 28;
+		uint32_t rendertargetsliceoffset : 3;
+	};
+	uint32_t asuint;
+} OrbisGnmDrawIndexFlags;

--- a/include/orbis/_types/video.h
+++ b/include/orbis/_types/video.h
@@ -21,6 +21,15 @@ typedef enum OrbisFlipRate : int32_t
 	ORBIS_VIDEO_OUT_FLIP_20HZ = 2,
 } OrbisFlipRate;
 
+typedef enum OrbisVideoOutTilingMode {
+	ORBIS_VIDEO_OUT_TILING_MODE_TILE = 0x0,
+	ORBIS_VIDEO_OUT_TILING_MODE_LINEAR = 0x1,
+} OrbisVideoOutTilingMode;
+
+typedef enum OrbisVideoOutAspectRatio {
+	ORBIS_VIDEO_OUT_ASPECT_RATIO_16_9 = 0x0,
+} OrbisVideoOutAspectRatio;
+
 #define ORBIS_VIDEO_OUT_PIXEL_FORMAT_A8B8G8R8_SRGB 0x80002200
 
 // Struct Credits - psxdev


### PR DESCRIPTION
The GnmDriver definitions may be used by a program or library to setup GNM (draw) command buffers and submit them.
The VideoOut definitions are meant to be used with `sceVideoOutSetBufferAttribute` since tiling mode and aspect ratio are arguments to it.