### PR TITLE
kernel: replace BSD types with stdint's in kevent's flags

### DIFF
--- a/include/orbis/_types/kernel.h
+++ b/include/orbis/_types/kernel.h
@@ -60,8 +60,8 @@
 struct kevent {
 	uintptr_t	ident;		/* identifier for this event */
 	short		filter;	/* filter for event */
-	u_short	flags;
-	u_int		fflags;
+	uint16_t	flags;
+	uint32_t	fflags;
 	intptr_t	data;
 	void		*udata;	/* opaque user data identifier */
 };


### PR DESCRIPTION
This fixes an issue of undefined types when compiling programs without GNU extensions (for example, with `-std=c11`).
kevent's structure size and offsets remain the same with this change, so nothing should be broken by this.
Note that this doesn't solve using C++ without GNU extensions (like `-std=c++14`), since libcxx seems to have a hard dependency on some definitions guarded by extension macros (see [musl's locale.h](https://github.com/OpenOrbis/musl/blob/master/include/locale.h#L57) and [libcxx's __locale](https://github.com/OpenOrbis/llvm-project/blob/master/libcxx/include/__locale#L132)).

I've built and ran the graphics sample with this successfully (it uses kevent [here](https://github.com/OpenOrbis/OpenOrbis-PS4-Toolchain/blob/master/samples/_common/graphics.cpp#L173), OrbisKernelEvent is an alias)