### PR TITLE
Update CommonDialog.h

### DIFF
--- a/include/orbis/CommonDialog.h
+++ b/include/orbis/CommonDialog.h
@@ -1,6 +1,7 @@
 #ifndef _SCE_COMMON_DIALOG_H_
 #define _SCE_COMMON_DIALOG_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <orbis/_types/common_dialog.h>
 


### PR DESCRIPTION
Fixes
```
/OpenOrbis/PS4Toolchain/include/orbis/CommonDialog.h:14:1: error: unknown type name 'bool'
bool sceCommonDialogIsUsed();
^
1 error generated.
```