### PR TITLE
build library stub from separate file

### DIFF
--- a/samples/library_example/Makefile
+++ b/samples/library_example/Makefile
@@ -59,10 +59,10 @@ $(INTDIR)/%.o: $(PROJDIR)/%.c
 $(INTDIR)/%.o: $(PROJDIR)/%.cpp
 	$(CCX) $(CXXFLAGS) -o $@ $<
 
-$(INTDIR)/%.o.stub: $(PROJDIR)/%.c
+$(INTDIR)/%.o.stub: $(PROJDIR)/%.stub.c
 	$(CC) -target x86_64-pc-linux-gnu -ffreestanding -nostdlib -fno-builtin -fPIC -c $(TOOLCHAIN)/include -o $@ $<
 
-$(INTDIR)/%.o.stub: $(PROJDIR)/%.cpp
+$(INTDIR)/%.o.stub: $(PROJDIR)/%.stub.cpp
 	$(CCX) -target x86_64-pc-linux-gnu -ffreestanding -nostdlib -fno-builtin -fPIC -c $(TOOLCHAIN)/include -o $@ $<
 
 .PHONY: clean

--- a/samples/library_example/library_example/lib.stub.c
+++ b/samples/library_example/library_example/lib.stub.c
@@ -1,0 +1,4 @@
+int testLibraryFunction()
+{
+    return 0;
+}


### PR DESCRIPTION
Build was failing because lib.cpp in the library_example has a bunch of external dependencies. For building the *.stub files, the implementation doesn't matter, only having the right symbols matters (its sorta like a header but in a .so) Added a .stub.c file with the same testLibraryFunction and a empty impl.

this fixes the build being broken on master