### PR TITLE
linker: join all data sections into one

### DIFF
--- a/link.x
+++ b/link.x
@@ -72,7 +72,7 @@ SECTIONS
 	}
 
 	.data : {
-		*(.data)
+		*(.data .data.*)
 	}
 
 	.bss : {


### PR DESCRIPTION
Currently, when using musl's stdio handles (stdin, stdout and stderr), the linker generates additional data sections for their data.
However, (likely) due to the custom linker script, those new data sections' file data isn't loaded, causing it to be zero and breaking the handles. For example, stdout's fd becomes 0.

This patch changes the linker script to tell the linker to join all sections starting with `.data` into one, except for `.data.sce_process_param` and `.data.rel.ro`.
This fixes outputting data to stdout (with printf and all) with musl, along with C++'s iostream.
**NOTE:** C++ samples aren't working with LLVM 18 (should be from something unrelated), but 16 and 17 are working fine.

You can test this by building and running the graphics sample. You should see some strings originating from it.

Here's a comparison of readelf's output of an eboot.bin before this patch:
```plain
Section Headers:
  [Nr] Name                      Type                Address               Offset
       Size                      EntSize             Flags    Link  Info   Align
...
  [18] .data.sce_process_param   SHT_PROGBITS        0x0000000000040000  0x0000000000044000
       0x0000000000000050        0x0000000000000000   WA         0     0   16384
  [19] .data                     SHT_PROGBITS        0x0000000000040050  0x0000000000044050
       0x000000000000003c        0x0000000000000000   WA         0     0   8
  [20] .data.__stderr_FILE       SHT_PROGBITS        0x0000000000040090  0x0000000000044090
       0x00000000000000e8        0x0000000000000000   WA         0     0   8
  [21] .data.__stderr_used       SHT_PROGBITS        0x0000000000040178  0x0000000000044178
       0x0000000000000008        0x0000000000000000   WA         0     0   8
  [22] .data.__libc              SHT_PROGBITS        0x0000000000040180  0x0000000000044180
       0x0000000000000070        0x0000000000000000   WA         0     0   8
...
Program Headers:
  Type             Offset             VirtAddr           PhysAddr
                   FileSiz            MemSiz             Flags  Align
...
  LOAD             0x0000000000044000 0x0000000000040000 0x0000000000040000
                   0x000000000000008c 0x0000000000000278 RW     0x4000
```

And after patching:
```plain
  [18] .data.sce_process_param   SHT_PROGBITS        0x0000000000040000  0x0000000000044000
       0x0000000000000050        0x0000000000000000   WA         0     0   16384
  [19] .data                     SHT_PROGBITS        0x0000000000040050  0x0000000000044050
       0x00000000000001a0        0x0000000000000000   WA         0     0   8
...
  LOAD             0x0000000000044000 0x0000000000040000 0x0000000000040000
                   0x00000000000001f0 0x0000000000000278 RW     0x4000
```

Tested on a base PS4, FW 9.00 and (a slightly customized) MiraHEN.