### PR TITLE
Fix ‎SystemService.h‎ bool

### DIFF
--- a/include/orbis/SystemService.h
+++ b/include/orbis/SystemService.h
@@ -1,6 +1,7 @@
 #ifndef _SCE_SYSTEM_SERVICE_H_
 #define _SCE_SYSTEM_SERVICE_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <orbis/_types/sys_service.h>


### PR DESCRIPTION
```
OpenOrbis/PS4Toolchain/include/orbis/SystemService.h:90:1: error: unknown type name 'bool'
   90 | bool sceSystemStateMgrIsStandbyModeEnabled(); 
      | ^
1 error generated.
```