### PR TITLE
Fix Windows installer and update README doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ If you don't wish to restart your shell, remember to `source` your updated profi
 This is needed so the build scripts and the converter tool know where to look for certain files. It is also recommended you add the root SDK directory + `/bin` to your path variable.
 
 ### Windows Installer
-For Windows, a Nullsoft scriptable installer is provided, which will automate the process of extracting the toolchain files and setting the `OO_PS4_TOOLCHAIN` environment variable.
+For Windows, an [Inno Setup 7](https://jrsoftware.org/isdl.php) installer in the `/extra` folder is provided, which will automate the process of extracting the toolchain files and setting the `OO_PS4_TOOLCHAIN` environment variable.
 
-Dependency [.NET Core 3.0 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-3.0.3-windows-x64-installer) is required to run LibOrbisPkg tools as part of build process.
+After installation, the compiled installer will be placed in the `installer-output` folder in the project root.
 
 ### Linux
 For Linux, after installing the required dependencies and setting up the environment variable as noted above, you should be good to go.
@@ -89,7 +89,7 @@ For macOS, a PKG installer is provided, which will automate the process of extra
 
 ## Creating Homebrew Projects
 
-For Windows, `/extra` provides Visual Studio templates which can be added into your VS installation's templates directory to allow easy creation of homebrew projects. You can also copy and modify the solutions from the provided samples.
+For Windows, `/extra` provides project templates (SPRX and SELF) which can be extracted and used to create homebrew projects. You can also copy and modify the solutions from the provided samples.
 
 For Linux and macOS, `/extra` contains a `setup-project.sh` script which will create a project directory based on the `hello_world` sample.
 

--- a/extra/installer.iss
+++ b/extra/installer.iss
@@ -5,7 +5,6 @@
 #define MyAppVersion "0.5.2"
 #define MyAppPublisher "OpenOrbis"
 #define MyAppURL "http://www.github.com/openorbis"
-#define Toolchain GetEnv('OO_PS4_TOOLCHAIN_SRC')
 
 [Setup]
 ; Tell Windows Explorer to reload the environment
@@ -23,25 +22,25 @@ AppUpdatesURL={#MyAppURL}
 DefaultDirName=C:\OpenOrbis\PS4Toolchain
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
-LicenseFile={#Toolchain}\LICENSE
-InfoBeforeFile={#Toolchain}\extra\readme.txt
+LicenseFile=..\LICENSE
+InfoBeforeFile=readme.txt
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
-OutputDir={#Toolchain}\
+OutputDir=..\installer-output
 OutputBaseFilename=OpenOrbis PS4 Toolchain
-SetupIconFile={#Toolchain}\extra\logo.ico
+SetupIconFile=logo.ico
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
-WizardSmallImageFile={#Toolchain}\extra\installer-wizard-small.bmp
-WizardImageFile={#Toolchain}\extra\installer-wizard-large.bmp
+WizardSmallImageFile=installer-wizard-small.bmp
+WizardImageFile=installer-wizard-large.bmp
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "{#Toolchain}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Code]
@@ -49,11 +48,6 @@ const
   SMTO_ABORTIFHUNG = 2;
   WM_WININICHANGE = $001A;
   WM_SETTINGCHANGE = WM_WININICHANGE;
-
-type
-  WPARAM = UINT_PTR;
-  LPARAM = INT_PTR;
-  LRESULT = INT_PTR;
 
 function SendTextMessageTimeout(hWnd: HWND; Msg: UINT;
   wParam: WPARAM; lParam: PAnsiChar; fuFlags: UINT;


### PR DESCRIPTION
This PR addresses several issues in the Windows section of the README and the Inno Setup installer configuration:

**Changes:**
- **README.md:**
  - Fixed "Nullsoft scriptable installer" to "Inno Setup installer" to correctly identify the installer technology
  - Removed outdated `.NET Core 3.0 Runtime` dependency claim (no evidence of LibOrbisPkg in codebase)
  - Updated Visual Studio templates description to accurately reflect the SPRX andSELF project templates in `/extra`
  - Clarified installer output location (`installer-output` folder)
- **extra/installer.iss:**
  - Removed dependency on `OO_PS4_TOOLCHAIN_SRC` environment variable
  - Replaced with relative paths (relative to .iss file location in `extra/`)
  - Output now goes to `installer-output` folder instead of project root

**Testing:**
- Verified installer compiles successfully with Inno Setup
- Confirmed all relative paths resolve correctly